### PR TITLE
Issue Resolved - Date Changing with Time Zone

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,18 +24,14 @@ function App() {
   const timezones = Intl.supportedValuesOf('timeZone')
 
   useEffect(() => {
+    document.title = timezone
+    setDate(dayjs().tz(timezone).format("dddd, D MMM, YYYY"))
     const interval = setInterval(() => {
       setTime(dayjs().tz(timezone).format('HH:mm:ss'))
     }, 1000)
     return () => clearInterval(interval)
   }, [timezone])
-
-  useEffect(() => {
-    document.title = timezone
-    const currentDate = dayjs().tz(timezone).format("dddd, D MMM, YYYY");
-    setDate(currentDate);
-  }, [timezone])
-
+  
   const customStyles = {
     overlay: {
       position: 'fixed',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,8 @@ function App() {
 
   useEffect(() => {
     document.title = timezone
+    const currentDate = dayjs().tz(timezone).format("dddd, D MMM, YYYY");
+    setDate(currentDate);
   }, [timezone])
 
   const customStyles = {


### PR DESCRIPTION
In the updated code, the useEffect hook for timezone now also updates the date by calling setDate(currentDate) whenever the timezone changes. This ensures that the date is correctly updated when the user selects a new timezone.